### PR TITLE
changes to move gles2 shader header file generation into external script

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 def add_source_files(self, sources, filetype, lib_env = None, shared = False):
 	import glob;
@@ -1107,10 +1108,6 @@ def build_legacygl_headers( target, source, env ):
 
 	return 0
 
-def build_gles2_headers( target, source, env ):
-
-	for x in source:
-		build_legacygl_header(str(x), include="drivers/gles2/shader_gles2.h", class_suffix = "GLES2", output_attribs = True)
 
 def update_version():
 
@@ -1446,3 +1443,37 @@ def colored(sys,env):
 	env.Append( JARCOMSTR=[java_library_message] )
 	env.Append( JAVACCOMSTR=[java_compile_source_message] )
 
+
+# Swap to running as external process. Hopefully avoiding generated file race conditions.
+build_gles2_headers = "%s methods.py build_gles2_headers --file ${SOURCES}"%(sys.executable,)
+# def __build_gles2_headers( target, source, env ):
+
+# 	for x in source:
+# 		build_legacygl_header(str(x), include="drivers/gles2/shader_gles2.h", class_suffix = "GLES2", output_attribs = True)
+
+
+def _build_gles2_headers(input_file):
+	target_file = input_file + ".h"
+	# __build_gles2_headers( target_file, [input_file,], None )
+	build_legacygl_header(input_file, include="drivers/gles2/shader_gles2.h", class_suffix = "GLES2", output_attribs = True)
+
+
+
+
+def _main():
+	import argparse
+	# create the top-level parser
+	parser = argparse.ArgumentParser()
+	# parser.add_argument('--foo', action='store_true', help='foo help')
+	subparsers = parser.add_subparsers(help='sub-command help')
+
+	# create the parser for the "a" command
+	parser_a = subparsers.add_parser('build_gles2_headers', help='Create gles2 headers from template')
+	parser_a.add_argument('--file', help='File template to use')
+	parser_a.set_defaults(func=_build_gles2_headers)
+	args = parser.parse_args()
+	args.func(args.file)
+
+
+if __name__ == "__main__":
+    _main()

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -90,6 +90,7 @@ import os
 
 import sys
 
+from SCons.Script import *
 
 def is_active():
 	return True
@@ -384,7 +385,7 @@ def configure(env):
 	env.Append( BUILDERS = { 'GLSL120' : env.Builder(action = methods.build_legacygl_headers, suffix = 'glsl.h',src_suffix = '.glsl') } )
 	env.Append( BUILDERS = { 'GLSL' : env.Builder(action = methods.build_glsl_headers, suffix = 'glsl.h',src_suffix = '.glsl') } )
 	env.Append( BUILDERS = { 'HLSL9' : env.Builder(action = methods.build_hlsl_dx9_headers, suffix = 'hlsl.h',src_suffix = '.hlsl') } )
-	env.Append( BUILDERS = { 'GLSL120GLES' : env.Builder(action = methods.build_gles2_headers, suffix = 'glsl.h',src_suffix = '.glsl') } )
+	env.Append( BUILDERS = { 'GLSL120GLES' : Builder(action = methods.build_gles2_headers, suffix = 'glsl.h',src_suffix = '.glsl') } )
 
 def detect_visual_c_compiler_version(tools_env):
         # tools_env is the variable scons uses to call tools that execute tasks, SCons's env['ENV'] that executes tasks...


### PR DESCRIPTION
changes to move gles2 shader header file generation into external script instead of internal python logic. This should avoid the race condition previously found when running parallel builds.

Note that these changes resolve the race conditions for these files, but building with -j6 revealed similar issue with other generated header files.  Likely you'll need to do this for all such logic.

Also note that the changes to platforms/windows/detect.py should be propagated to all the other platforms which specify the GLSL120GLES builder.
